### PR TITLE
Hotfix

### DIFF
--- a/gesture_detection_main.py
+++ b/gesture_detection_main.py
@@ -24,14 +24,23 @@ def main():
     gesture_detector_data = gesture_detection.init()
     # begin capture of video
     cap = cv2.VideoCapture(0)
-
+    gesture_list = []
+    frames = 8
     while True:
         # read current frame from camera
         _, img = cap.read()
 
         # detect is a circle pattern is recognized
         pattern_detection.run(img, pattern_detection_data)
-        gesture = gesture_detection.run(img, gesture_detector_data)
+        # detect if a gesture is recognized and push it into the queue
+        gesture_list.append(gesture_detection.run(img, gesture_detector_data))
+        # check if the gesture has been detected for a certain amount of frames
+        if len(gesture_list) >= frames:
+            if gesture_list.count(gesture_list[0]) == len(gesture_list) and gesture_list[0] is not None:
+                # print the gesture
+                print(gesture_list[0])
+            # clear the list
+            gesture_list.clear()
         ############## FOR TESTING PURPOSES ##############
         ############  REMOVING AFTER TESTING  ############
         # show window (this will contain the gesture path)

--- a/nest.py
+++ b/nest.py
@@ -43,7 +43,7 @@ class _Helper:
     from_f_to_celsuis = lambda fahrenheit : round((fahrenheit - 32) / 1.8, 1)
     
     # headers for API Calls
-    def get_headers():
+    def get_headers(self):
         return {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {_Helper.ACCESS_TOKEN}',

--- a/nest.py
+++ b/nest.py
@@ -43,14 +43,16 @@ class _Helper:
     from_f_to_celsuis = lambda fahrenheit : round((fahrenheit - 32) / 1.8, 1)
     
     # headers for API Calls
-    def get_headers(self):
+    @staticmethod
+    def get_headers():
         return {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {_Helper.ACCESS_TOKEN}',
         }
     
     # params for API Calls
-    def get_params(self, value, command):
+    @staticmethod
+    def get_params(value, command):
         param = ""
         command_mode = "ThermostatTemperatureSetpoint" if command in {_Helper.COOL_COMMAND, _Helper.HEAT_COMMAND} \
             else "ThermostatMode"

--- a/nest.py
+++ b/nest.py
@@ -50,7 +50,7 @@ class _Helper:
         }
     
     # params for API Calls
-    def get_params(value, command):
+    def get_params(self, value, command):
         param = ""
         command_mode = "ThermostatTemperatureSetpoint" if command in {_Helper.COOL_COMMAND, _Helper.HEAT_COMMAND} \
             else "ThermostatMode"

--- a/nest_secrets.py
+++ b/nest_secrets.py
@@ -1,11 +1,11 @@
 # comment this line if you are using your own data
-from nest_secrets_private import PROJECT_ID, DEVICE_ID, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN
+# from nest_secrets_private import PROJECT_ID, DEVICE_ID, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN
 
 # add your own data
 # information needed to access NEST API
 # comment these lines if you are using your own data
-# PROJECT_ID = ""
-# DEVICE_ID = ""
-# CLIENT_ID = ""
-# CLIENT_SECRET = ""
-# REFRESH_TOKEN = ""
+PROJECT_ID = ""
+DEVICE_ID = ""
+CLIENT_ID = ""
+CLIENT_SECRET = ""
+REFRESH_TOKEN = ""

--- a/spotify.py
+++ b/spotify.py
@@ -25,7 +25,8 @@ class _Helper:
     token_expiration = None
 
     # Return header info for API calls
-    def get_headers(self):
+    @staticmethod
+    def get_headers():
         return {
             'Authorization': f"Bearer {_Helper.access_token}"
         }

--- a/spotify.py
+++ b/spotify.py
@@ -25,7 +25,7 @@ class _Helper:
     token_expiration = None
 
     # Return header info for API calls
-    def get_headers():
+    def get_headers(self):
         return {
             'Authorization': f"Bearer {_Helper.access_token}"
         }

--- a/spotify_secrets.py
+++ b/spotify_secrets.py
@@ -1,10 +1,10 @@
 # comment this line if you are using your own data
-from spotify_secrets_private import DEVICE_ID, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN
+# from spotify_secrets_private import DEVICE_ID, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN
 
 # add your own data
 # information needed to access Spotify API
 # comment these lines i you are using your own data
-# DEVICE_ID = ""
-# CLIENT_ID = ""
-# CLIENT_SECRET = ""
-# REFRESH_TOKEN = ""
+DEVICE_ID = ""
+CLIENT_ID = ""
+CLIENT_SECRET = ""
+REFRESH_TOKEN = ""


### PR DESCRIPTION
As for the latest commit please note the following. Python class methods usually have 'self' as the first parameter unless they are static or class methods. In which case they should be labeled as such. This is also just a convention so if it works without it that's fine.